### PR TITLE
fix: remove unsupported FastMCP parameters to resolve TypeError

### DIFF
--- a/grafana_loki_mcp/server.py
+++ b/grafana_loki_mcp/server.py
@@ -25,8 +25,6 @@ mcp = FastMCP(
     "Grafana-Loki Query Server",
     host="0.0.0.0",
     port=52229,
-    allow_iframe=True,
-    allow_cors=True,
 )
 
 # Default configuration


### PR DESCRIPTION
Fixes #19

The FastMCP constructor was being called with unsupported parameters that caused a TypeError when running the package:

- `allow_iframe=True` (causing TypeError)
- `allow_cors=True` (also unsupported)

Removed these parameters to fix the crash when running `uvx grafana-loki-mcp@0.1.3`.

Generated with [Claude Code](https://claude.ai/code)