### PR TITLE
feat: add MAX_LOG_LINES environment variable support

### DIFF
--- a/grafana_loki_mcp/server.py
+++ b/grafana_loki_mcp/server.py
@@ -30,6 +30,7 @@ mcp = FastMCP(
 # Default configuration
 DEFAULT_GRAFANA_URL = os.environ.get("GRAFANA_URL", "")
 DEFAULT_GRAFANA_API_KEY = os.environ.get("GRAFANA_API_KEY", "")
+DEFAULT_MAX_LOG_LINES = int(os.environ.get("MAX_LOG_LINES", "100"))
 
 
 class GrafanaClient:
@@ -554,7 +555,7 @@ def query_loki(
         Optional[str],
         "End time (Grafana format like 'now', ISO format, Unix timestamp, or RFC3339)",
     ] = None,
-    limit: Annotated[int, "Maximum number of log lines to return"] = 100,
+    limit: Annotated[int, "Maximum number of log lines to return"] = DEFAULT_MAX_LOG_LINES,
     direction: Annotated[str, "Query direction ('forward' or 'backward')"] = "backward",
     max_per_line: Annotated[
         int, "Maximum characters per log line (0 for unlimited)"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -328,3 +328,31 @@ def test_query_loki_time_range(
     # Expect nanoseconds since epoch for ISO8601 as strings
     assert kwargs["params"]["start"] == "1710410400000000000"
     assert kwargs["params"]["end"] == "1710414000000000000"
+
+
+@patch.dict(os.environ, {"MAX_LOG_LINES": "50"})
+def test_max_log_lines_environment_variable() -> None:
+    """Test that MAX_LOG_LINES environment variable is used as default."""
+    # Import after setting environment variable to ensure it's picked up
+    import importlib
+    
+    # Force reload the module to pick up the new environment variable
+    import grafana_loki_mcp.server
+    importlib.reload(grafana_loki_mcp.server)
+    
+    # Check that the environment variable is properly read
+    assert grafana_loki_mcp.server.DEFAULT_MAX_LOG_LINES == 50
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_max_log_lines_default_value() -> None:
+    """Test that MAX_LOG_LINES defaults to 100 when not set."""
+    # Import after clearing environment variables
+    import importlib
+    
+    # Force reload the module to pick up the cleared environment
+    import grafana_loki_mcp.server
+    importlib.reload(grafana_loki_mcp.server)
+    
+    # Check that the default value is used
+    assert grafana_loki_mcp.server.DEFAULT_MAX_LOG_LINES == 100


### PR DESCRIPTION
This PR implements support for configuring the maximum number of log lines returned by the query_loki tool via the MAX_LOG_LINES environment variable.

## Changes
- Added DEFAULT_MAX_LOG_LINES environment variable with default value of 100
- Updated query_loki MCP tool to use configurable limit instead of hardcoded value
- Added comprehensive tests to verify environment variable functionality

## Usage
Users can now set the maximum number of log lines by setting the MAX_LOG_LINES environment variable:
```bash
export MAX_LOG_LINES=200
python -m grafana_loki_mcp
```

Closes #22

Generated with [Claude Code](https://claude.ai/code)